### PR TITLE
Fix for stuck overline when triggerd by code

### DIFF
--- a/Classes/BFPaperTabBarController.m
+++ b/Classes/BFPaperTabBarController.m
@@ -376,8 +376,14 @@ CGFloat const bfPaperTabBarController_tapCircleDiameterDefault = -2.f;
 {
     [self setSelectedIndex:index];
     self.selectedTabIndex = index;
-    [self setUnderlineForTabIndex:index animated:animated];
     [self setBackgroundFadeLayerForTabAtIndex:index];
+    
+    if (self.showTopLine)
+        [self setToplineForTabIndex:index animated:NO];
+    
+    if (self.showUnderline)
+        [self setUnderlineForTabIndex:index animated:NO];
+    
 }
 
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ Please refer to this [CHANGELOG.md](https://github.com/bfeher/BFPaperTabBarContr
 `BOOL showUnderline`  
 > A flag to set to `YES` to show an underline bar that tracks the currently selected tab.  
 
+`BOOL showTopLine`  
+> A flag to set to `YES` to show an overline bar that tracks the currently selected tab.  
+
 `BOOL showTapCircleAndBackgroundFade`  
 > A flag to set to `YES` to show the tap-circle and background fade. If `NO`, they will not appear.  
 


### PR DESCRIPTION
When calling `[self selectTabAtIndex:1 animated:true];`, the overline bar stuck at its position while underline is moving. This fix will try to move both line if they are enabled.