### PR TITLE
Fix crash at manual init

### DIFF
--- a/BFPaperTabBarController.podspec
+++ b/BFPaperTabBarController.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "BFPaperTabBarController"
-  s.version      = "2.2.9"
+  s.version      = "2.2.10"
   s.summary      = "iOS UITabBar inspired by Google's Paper Material Design."
   s.homepage     = "https://github.com/bfeher/BFPaperTabBar"
   s.license      = { :type => 'MIT', :file => 'LICENSE.md' }
   s.author       = { "Bence Feher" => "ben.feher@gmail.com" }
-  s.source       = { :git => "https://github.com/bfeher/BFPaperTabBarController.git", :tag => "2.2.9" }
+  s.source       = { :git => "https://github.com/bfeher/BFPaperTabBarController.git", :tag => s.version.to_s }
   s.platform     = :ios, '7.0'
   s.source_files = 'Classes/*.{h,m}'
   s.requires_arc = true

--- a/Classes/BFPaperTabBarController.m
+++ b/Classes/BFPaperTabBarController.m
@@ -167,6 +167,12 @@ CGFloat const bfPaperTabBarController_tapCircleDiameterDefault = -2.f;
     }
 }
 
+- (void)setViewControllers:(NSArray<__kindof UIViewController *> * __nullable)viewControllers animated:(BOOL)animated {
+	[super setViewControllers:viewControllers animated:animated];
+	
+	self.tabRects = nil;
+}
+
 
 #pragma mark - Setup
 - (void)setupBFPaperTabBarController


### PR DESCRIPTION
In our project, we faced with a crash similar to https://github.com/bfeher/BFPaperTabBarController/issues/3. It was because tabRects array was set by empty array at tabbar vc initialization and later it will not be recreated when new view controllers are set. So it needs just set it to nil when new view controllers are set and it will be recreated at next accessing.